### PR TITLE
improved sourcing in include function

### DIFF
--- a/initial-manifest
+++ b/initial-manifest
@@ -22,16 +22,23 @@ CDISTSOURCE() {
 
 # Safe include function for manifests including other manifests
 include() {
-   local i dir manifest=''
+   local i dir manifest='' cdistaction
 
-   if [[ ! "$CDISTACTION" && -e "${__manifest}/autorun/${1}" ]]; then
-      return 0
-   fi
+   test "$CDISTACTION" = "" -a -e "${__manifest}/${MANIFESTALL}/${1}" && return 0
 
    if test $(basename "${1}") == $(basename "${__cdist_manifest}"); then
       echo "ERROR: The init manifest itself cannot be included"
       exit 1
    fi
+
+   unset cdistaction
+   for manifest in ${CDISTACTION//,/ }; do
+      if test -f "$__manifest/$manifest"; then
+         cdistaction+=( "$__manifest/$manifest" )
+      elif test -f "$__manifest/$MANIFESTALL/$manifest"; then
+         cdistaction+=( "$__manifest/$MANIFESTALL/$manifest" )
+      fi
+   done
 
    for dir in ${__manifest}/ $(ls -d ${__manifest}/*/); do
       if test -e "${dir}${1}"; then
@@ -40,12 +47,12 @@ include() {
       fi
    done
 
-   for i in "${SOURCESTACK[@]}}"; do
+   for i in "${cdistaction[@]}" "${SOURCESTACK[@]}}"; do
       if test "${i}" == "${manifest}"; then
          read line func file < <(caller)
          test -z "${file}" && file="${func}"
          file=$(basename "${file}")
-         echo "ERROR: Circular include for manifest '${file}' from '${1}'"
+         echo "ERROR: Circular/multiple include(s) of ${1} in manifest ${file}"
          exit 1
       fi
    done

--- a/initial-manifest
+++ b/initial-manifest
@@ -24,7 +24,10 @@ CDISTSOURCE() {
 include() {
    local i dir manifest=''
 
-   ! test "$CDISTACTION" && return 0
+   if [[ ! "$CDISTACTION" && -e "${__manifest}/autorun/${1}" ]]; then
+      return 0
+   fi
+
    if test $(basename "${1}") == $(basename "${__cdist_manifest}"); then
       echo "ERROR: The init manifest itself cannot be included"
       exit 1


### PR DESCRIPTION
when no cdistaction is defined and:
- include file is present in autorun directory then return 0
- include file is NOT present in autorun directory then do try to source the inlude file