### PR TITLE
Reset sourcestack when running a new manifest

### DIFF
--- a/initial-manifest
+++ b/initial-manifest
@@ -22,7 +22,7 @@ CDISTSOURCE() {
 
 # Safe include function for manifests including other manifests
 include() {
-   local i dir manifest='' cdistaction
+   local i dir include_manifest=''
 
    test "$CDISTACTION" = "" -a -e "${__manifest}/${MANIFESTALL}/${1}" && return 0
 
@@ -31,24 +31,20 @@ include() {
       exit 1
    fi
 
-   unset cdistaction
-   for manifest in ${CDISTACTION//,/ }; do
-      if test -f "$__manifest/$manifest"; then
-         cdistaction+=( "$__manifest/$manifest" )
-      elif test -f "$__manifest/$MANIFESTALL/$manifest"; then
-         cdistaction+=( "$__manifest/$MANIFESTALL/$manifest" )
-      fi
-   done
-
    for dir in ${__manifest}/ $(ls -d ${__manifest}/*/); do
       if test -e "${dir}${1}"; then
-         manifest="${dir}${1}"
+         include_manifest="${dir}${1}"
          break
       fi
    done
 
-   for i in "${cdistaction[@]}" "${SOURCESTACK[@]}}"; do
-      if test "${i}" == "${manifest}"; then
+   # reset SOURCESTACK when this function is called from a new manifest
+   if [[ ! " ${SOURCESTACK[*]} " =~ " ${manifest} " ]]; then
+      SOURCESTACK=("${manifest}")
+   fi
+
+   for i in "${SOURCESTACK[@]}}"; do
+      if test "${i}" == "${include_manifest}"; then
          read line func file < <(caller)
          test -z "${file}" && file="${func}"
          file=$(basename "${file}")
@@ -57,9 +53,9 @@ include() {
       fi
    done
 
-   if ! test -z "${manifest}"; then
-      SOURCESTACK+=("${manifest}")
-      CDISTSOURCE "$manifest"
+   if ! test -z "${include_manifest}"; then
+      SOURCESTACK+=("${include_manifest}")
+      CDISTSOURCE "$include_manifest"
    else
       return 1
    fi


### PR DESCRIPTION
To be able to use the same include in multiple manifests it's necessary to reset the sourcestack when calling function include from a new manifest. $manifest is a global variable, so to be able to use that I renamed 'local manifest' to 'local include_manifest'. Variable cdistaction is now obsolete and replaced by $manifest